### PR TITLE
Feature add support for fetching OpenAPI schema from a remote FastAPI server

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,30 @@ mcp.mount()
 
 That's it! Your auto-generated MCP server is now available at `https://app.base.url/mcp`.
 
+## Remote OpenAPI Schema
+
+You can configure FastApiMCP to fetch the OpenAPI schema from a remote FastAPI server by providing a custom httpx.AsyncClient and setting `fetch_openapi_from_remote=True`:
+
+```python
+import httpx
+from fastapi import FastAPI
+from fastapi_mcp import FastApiMCP
+
+REMOTE_API_URL = "http://127.0.0.1:5000"
+app = FastAPI()
+client = httpx.AsyncClient(base_url=REMOTE_API_URL)
+
+mcp = FastApiMCP(
+    app,
+    name="MCP for Remote API",
+    http_client=client,
+    fetch_openapi_from_remote=True,
+)
+mcp.mount()
+```
+
+If `fetch_openapi_from_remote` is set and a custom client is provided, FastApiMCP will retrieve the OpenAPI schema from the remote server's `/openapi.json` endpoint instead of generating it locally.
+
 ## Documentation, Examples and Advanced Usage
 
 FastAPI-MCP provides [comprehensive documentation](https://fastapi-mcp.tadata.com/). Additionaly, check out the [examples directory](examples) for code samples demonstrating these features in action.

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -165,7 +165,8 @@ class FastApiMCP:
         if self.fetch_openapi_from_remote and self._http_client:
 
             async def fetch_openapi():
-                resp = await self._http_client.get("/openapi.json")
+                openapi_url = getattr(self.fastapi, "openapi_url", "/openapi.json")
+                resp = await self._http_client.get(openapi_url)
                 resp.raise_for_status()
                 return resp.json()
 

--- a/fastapi_mcp/server.py
+++ b/fastapi_mcp/server.py
@@ -145,7 +145,7 @@ class FastApiMCP:
         self._include_tags = include_tags
         self._exclude_tags = exclude_tags
         self._auth_config = auth_config
-        self.fetch_openapi_from_remote = fetch_openapi_from_remote
+        self._fetch_openapi_from_remote = fetch_openapi_from_remote
 
         if self._auth_config:
             self._auth_config = self._auth_config.model_validate(self._auth_config)

--- a/tests/test_remote_openapi.py
+++ b/tests/test_remote_openapi.py
@@ -22,7 +22,7 @@ def test_fetch_openapi_from_remote(monkeypatch):
     client = MockAsyncClient()
     mcp = FastApiMCP(app, http_client=client, fetch_openapi_from_remote=True)
     # The openapi schema should be fetched from remote
-    assert mcp.tools is not None
+    assert mcp.tools == []  # tools should be an empty list since paths is empty
     assert mcp.operation_map is not None
     # The schema should match what the mock returned
     assert mcp.operation_map == {}  # since paths is empty

--- a/tests/test_remote_openapi.py
+++ b/tests/test_remote_openapi.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi import FastAPI
+from fastapi_mcp import FastApiMCP
+
+
+@pytest.mark.asyncio
+def test_fetch_openapi_from_remote(monkeypatch):
+    app = FastAPI()
+    remote_openapi = {"openapi": "3.0.0", "info": {"title": "Remote", "version": "1.0.0"}, "paths": {}}
+
+    class MockAsyncClient:
+        async def get(self, url):
+            class Resp:
+                def raise_for_status(self):
+                    pass
+
+                def json(self):
+                    return remote_openapi
+
+            return Resp()
+
+    client = MockAsyncClient()
+    mcp = FastApiMCP(app, http_client=client, fetch_openapi_from_remote=True)
+    # The openapi schema should be fetched from remote
+    assert mcp.tools is not None
+    assert mcp.operation_map is not None
+    # The schema should match what the mock returned
+    assert mcp.operation_map == {}  # since paths is empty


### PR DESCRIPTION
## Describe your changes

## Issue ticket number and link (if applicable)

## Screenshots of the feature / bugfix

## Checklist before requesting a review
- [ ] Added relevant tests
- [ ] Run ruff & mypy
- [ ] All tests pass

## Summary by Sourcery

Add optional remote OpenAPI schema fetch support to FastApiMCP, with fallback to local generation on error, and document and test the new capability.

New Features:
- Enable fetching OpenAPI schema from a remote FastAPI server when an http client and `fetch_openapi_from_remote` flag are provided.

Enhancements:
- Fall back to local OpenAPI generation if remote fetch fails.

Documentation:
- Add README instructions for configuring remote OpenAPI schema fetching.

Tests:
- Add async test to verify remote OpenAPI schema retrieval and subsequent tool generation.